### PR TITLE
Update MediaFilePreviewImpl.java

### DIFF
--- a/server/src/main/java/cn/keking/service/impl/MediaFilePreviewImpl.java
+++ b/server/src/main/java/cn/keking/service/impl/MediaFilePreviewImpl.java
@@ -132,7 +132,7 @@ public class MediaFilePreviewImpl implements FilePreview {
             File desFile=new File(fileName);
             //判断一下防止穿透缓存
             if(desFile.exists()){
-                return fileName;
+                return convertFileName;
             }
 
             frameGrabber.start();


### PR DESCRIPTION
If converted file exists, should return the file's url, not the absolute filepath.